### PR TITLE
Window Maximum Size Set

### DIFF
--- a/BigPythonEnergy/MainWindowUI.py
+++ b/BigPythonEnergy/MainWindowUI.py
@@ -16,6 +16,7 @@ class Ui_MainWindow(object):
         MainWindow.setObjectName("MainWindow")
         MainWindow.resize(800, 600)
         MainWindow.setMinimumSize(QtCore.QSize(800, 600))
+        MainWindow.setMaximumSize(QtCore.QSize(800, 600))
         MainWindow.setSizeIncrement(QtCore.QSize(1, 1))
         MainWindow.setBaseSize(QtCore.QSize(800, 600))
         icon = QtGui.QIcon()

--- a/BigPythonEnergy/ui/gameBox.ui
+++ b/BigPythonEnergy/ui/gameBox.ui
@@ -16,6 +16,12 @@
     <height>600</height>
    </size>
   </property>
+  <property name="maximumSize">
+   <size>
+    <width>800</width>
+    <height>600</height>
+   </size>
+  </property>
   <property name="sizeIncrement">
    <size>
     <width>1</width>


### PR DESCRIPTION
The maximum size of the main game window has been set to 800x600 so that the window can not be resized at all.